### PR TITLE
Removed excluding last played maps, added CreateExcludeList function,…

### DIFF
--- a/morbusgame/gamemode/init.lua
+++ b/morbusgame/gamemode/init.lua
@@ -67,7 +67,7 @@ CreateConVar("morbus_mission_time_max", "180", FCVAR_NOTIFY)
 CreateConVar("morbus_mission_time_min", "120", FCVAR_NOTIFY)
 CreateConVar("morbus_mission_next_time_max", "80", FCVAR_NOTIFY)
 CreateConVar("morbus_mission_next_time_min", "160", FCVAR_NOTIFY)
-
+CreateConVar("morbus_exclude_last_played", "0", FCVAR_NOTIFY)
 
 CreateConVar("morbus_rpnames_optional", "0", FCVAR_NOTIFY)
 -----------------------------------------------

--- a/morbusgame/gamemode/server/sv_maps.lua
+++ b/morbusgame/gamemode/server/sv_maps.lua
@@ -77,7 +77,6 @@ util.AddNetworkString("smv_winner")
 
 
 SMV.VoteTime = 30
-SMV.OptionCount = 4
 SMV.Voting = false
 SMV.Votes = {}
 SMV.TVotes = {}
@@ -85,118 +84,9 @@ SMV.TVotes = {}
 SMV.MapVoteList = {}
 
 function SMV.CreateMapList()
-	SMV.ExcludedMaps = {}
 	
-	--read prevous maps and convert to table format
-	local lastMaps = util.JSONToTable( file.Read( "lastmaps.txt") )
-	
-	--insert the current map into the table
-	local currentMap = game.GetMap()
-	table.insert(lastMaps, 1, currentMap)
-	
-	--exclude maps based on player count	
-	local playerCount = GetValidCount()	
-	
-	local excludeString = ""
-	
-	if playerCount < 18 then
-		table.insert(SMV.ExcludedMaps, "mor_horizon_v11_re")
-		
-		if playerCount < 12 then	
-			table.insert(SMV.ExcludedMaps, "mor_installation_gt1_re")
-			table.insert(SMV.ExcludedMaps, "mor_outpostnorth32_a5")
-			table.insert(SMV.ExcludedMaps, "mor_auriga_v4_re")
-			table.insert(SMV.ExcludedMaps, "mor_ptmc_v22")				
-			excludeString = "large"
-			SMV.OptionCount = 4
-						
-			if playerCount < 8 then
-				--table.insert(SMV.ExcludedMaps, "mor_skandalon_b5_re")
-				table.insert(SMV.ExcludedMaps, "mor_isolation_cv1")
-				table.insert(SMV.ExcludedMaps, "mor_facility_cv2")
-				table.insert(SMV.ExcludedMaps, "mor_turbatio")
-				
-				-- test changes, hard time populating on these maps
-				table.insert(SMV.ExcludedMaps, "mor_spaceship_v10_re")
-				SMV.OptionCount = 3
-				
-				if playerCount < 6 then
-					SMV.OptionCount = 2
-					table.insert(SMV.ExcludedMaps, "mor_breach_cv21")
-				end
-			end		
-		end	
-	end
-		
-	if playerCount > 15 then
-		table.insert(SMV.ExcludedMaps, "mor_isolation_b4_re")
-		table.insert(SMV.ExcludedMaps, "mor_temple_v1")
-		excludeString = "tiny"
-				
-		if playerCount > 18 then
-			table.insert(SMV.ExcludedMaps, "mor_alphastation_b4_re")
-			table.insert(SMV.ExcludedMaps, "mor_grem")
-			table.insert(SMV.ExcludedMaps, "mor_skandalon_b5_re")
-			excludeString = "tiny and small sized"
-			SMV.OptionCount = 3
-			
-			if playerCount > 23 then
-				table.insert(SMV.ExcludedMaps, "mor_spaceship_v10_re")
-				table.insert(SMV.ExcludedMaps, "mor_chemical_labs_b3_re")
-				table.insert(SMV.ExcludedMaps, "mor_isolation_cv1")
-				table.insert(SMV.ExcludedMaps, "mor_breach_cv21")
-				excludeString = "tiny, small and medium sized"
-				
-				if playerCount > 25 then
-					table.insert(SMV.ExcludedMaps, "mor_turbatio")
-					table.insert(SMV.ExcludedMaps, "mor_facility_cv2")
-					excludeString = "all non-large"
-					SMV.OptionCount = 2
-				end
-			end
-		end
-	end
-	
-	--Get how many options will appear in the voter
-	local optionCount = 0
-	for k,v in pairs(SMV.Maps) do
-		if !table.KeyFromValue(SMV.ExcludedMaps, v) then
-			if file.Exists("maps/"..v..".bsp","GAME") then
-				optionCount = optionCount + 1
-			end		
-		end	
-	end	
-	
-	--how many maps are in the excluded maps table?
-	local tableCount = table.Count(lastMaps)
-	
-	--Reduce the option count to a set amount by excluding previous maps
-	if optionCount > SMV.OptionCount then
-		for j=1, tableCount do					
-			if !table.KeyFromValue(SMV.ExcludedMaps, lastMaps[j]) then
-				table.insert(SMV.ExcludedMaps, lastMaps[j])
-				optionCount = optionCount - 1
-			end
-			
-			if optionCount == SMV.OptionCount then break end
-		end
-	end
-	
-	--Trim the map list of non-required repeats before writing to text
-	local uniqueMaps = {}
-	local lastMap = nil
-	for k=1, tableCount do
-		lastMap = lastMaps[k]
-		
-		if !table.KeyFromValue(uniqueMaps, lastMap) then
-			table.insert(uniqueMaps, lastMap)
-		end
-	end
-	
-	if GetValidCount() > 1 then
-		--convert the new map table to json and write to the text file
-		file.Write( "lastmaps.txt", util.TableToJSON( uniqueMaps, true  ) )
-	end
+	--build list of maps to exclude based on size and get exclude string 
+	SMV.ExcludedMaps, excludeString = SMV.CreateExcludeList()
 	
 	--clear table from previous round (safety feature)
 	table.Empty(SMV.MapVoteList)
@@ -219,6 +109,63 @@ function SMV.CreateMapList()
 	SMV.SendAll("[xG] There are "..table.Count(SMV.Maps).." total maps in rotations!")
 	SMV.SendAll("[xG] Player count thresholds have excluded "..excludeString.." maps!")	
 end
+
+
+--exclude maps based on player count	
+function SMV.CreateExcludeList()
+	SMV.ExcludedMaps = {}
+	local playerCount = GetValidCount()	
+	local excludeString = ""
+	
+	if playerCount < 20 then
+		table.insert(SMV.ExcludedMaps, "mor_horizon_v11_re")
+		
+		if playerCount < 12 then	
+			table.insert(SMV.ExcludedMaps, "mor_installation_gt1_re")
+			table.insert(SMV.ExcludedMaps, "mor_outpostnorth32_a5")
+			table.insert(SMV.ExcludedMaps, "mor_auriga_v4_re")
+			table.insert(SMV.ExcludedMaps, "mor_ptmc_v22")
+			table.insert(SMV.ExcludedMaps, "mor_breach_cv21")
+			excludeString = "large"
+						
+			if playerCount < 8 then
+				table.insert(SMV.ExcludedMaps, "mor_isolation_cv1")
+				table.insert(SMV.ExcludedMaps, "mor_facility_cv2")
+				table.insert(SMV.ExcludedMaps, "mor_turbatio")
+				
+				-- test changes, hard time populating on these maps
+				table.insert(SMV.ExcludedMaps, "mor_spaceship_v10_re")
+				
+				
+			end		
+		end	
+	end
+			
+	if playerCount > 18 then
+		table.insert(SMV.ExcludedMaps, "mor_isolation_b4_re")
+		table.insert(SMV.ExcludedMaps, "mor_temple_v1")
+		table.insert(SMV.ExcludedMaps, "mor_alphastation_b4_re")
+		table.insert(SMV.ExcludedMaps, "mor_grem")
+		table.insert(SMV.ExcludedMaps, "mor_skandalon_b5_re")
+		excludeString = "tiny and small sized"
+			
+		if playerCount > 23 then
+			table.insert(SMV.ExcludedMaps, "mor_spaceship_v10_re")
+			table.insert(SMV.ExcludedMaps, "mor_chemical_labs_b3_re")
+			table.insert(SMV.ExcludedMaps, "mor_isolation_cv1")
+			table.insert(SMV.ExcludedMaps, "mor_breach_cv21")
+			excludeString = "tiny, small and medium sized"
+				
+			if playerCount > 25 then
+				table.insert(SMV.ExcludedMaps, "mor_turbatio")
+				table.insert(SMV.ExcludedMaps, "mor_facility_cv2")
+				excludeString = "all non-large"
+			end
+		end
+	end
+	return SMV.ExcludedMaps, excludeString
+end
+
 
 function SMV.SendAll( msg )
 	for k, v in pairs( player.GetAll() ) do


### PR DESCRIPTION
… changed required maximum or minimum player counts for Breach_CV, Iso, and temple

Removed exclusion of the last played maps. Due to the dying state of the game, it would be recommended to give players the choice to extend play on the current map, or to only exclude the last n played maps (where n is a small non-negative integer, preferably 1 or 2. ).  Certain maps, such as chem labs or spaceship, bring players in when player counts are low and are enjoyable for long sessions. 

Added CreateExcludeList function, which returns a table of excluded maps and a string stating the size of the excluded maps. 

Min player count for Breach_cv increased from 5 to 12 as the map is very large. Max player counts for iso and temple have been increased from 15 to 18 as the maps are robust to large player counts.