### PR TITLE
Allow switching from medkit using lastinv command

### DIFF
--- a/morbusgame/entities/weapons/weapon_mor_medkit/shared.lua
+++ b/morbusgame/entities/weapons/weapon_mor_medkit/shared.lua
@@ -50,6 +50,7 @@ end
 
 function SWEP:Deploy()
    self.Weapon:SendWeaponAnim(ACT_VM_DRAW)
+   return true
 end
 
 function SWEP:PrimaryAttack()


### PR DESCRIPTION
The behavior for the medkit the last few years has been such that, if a player brings out the medkit they are unable to use their last inventory bind. I propose that we allow players to be able to switch to their last used weapon at ease, when holding the medkit.

[According the Gmod wiki](https://wiki.garrysmod.com/page/WEAPON/Deploy), its recommended Deploy return True, else Deploy returns false and players will be unable to switch to their last used weapon. 